### PR TITLE
Update reboot step to remove unnecessary stat step

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,25 +7,15 @@
   async: 600
   poll: 10
 
-
-- name: Check if reboot is required
-  stat:
-    path: /var/run/reboot-required
-  register: stat
-  changed_when: stat.stat.exists
-
-
 #
 # Reboot & wait derived from code written by Martin Eggen.
 # https://github.com/ansible/ansible/issues/14413#issuecomment-257887580
 # 
 
 - name: Reboot host
-  shell: sleep 2 && /sbin/shutdown -r now "Ansible reboot"
+  shell: sleep 2 && /sbin/shutdown -r now "Ansible reboot" removes=/var/run/reboot-required
   async: 1
   poll: 0
-  when: stat.stat.exists
-
 
 - name: Wait for host to be ready
   become: no

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,7 +13,9 @@
 # 
 
 - name: Reboot host
-  shell: sleep 2 && /sbin/shutdown -r now "Ansible reboot" removes=/var/run/reboot-required
+  shell: sleep 2 && /sbin/shutdown -r now "Ansible reboot" 
+  args: 
+    removes=/var/run/reboot-required
   async: 1
   poll: 0
 


### PR DESCRIPTION
Update reboot step per the Ansible docs to use the removes functionality of the shell module - http://docs.ansible.com/ansible/shell_module.html

The command will only run when /var/run/reboot-required exists.